### PR TITLE
first pass at creating example

### DIFF
--- a/.github/dependabot/go.yml
+++ b/.github/dependabot/go.yml
@@ -1,0 +1,18 @@
+# This is the input to Dependabot CLI.
+# For more examples of what you can do, see the smoke tests: https://github.com/dependabot/smoke-tests/tree/main/tests
+
+job:
+  # this is the directory defined in dependabot-core
+  package-manager: go_modules
+  allowed-updates:
+    - dependency-type: direct
+      update-type: all
+  experiments:
+    # unlike with hosted Dependabot, you can control this variable directly
+    goprivate: ""
+  source:
+    provider: github
+    repo: dependabot/example-cli-usage
+    # looks absolute, but this is relative to the root of the repo
+    directory: /example
+    branch: main

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,51 @@
+name: Run Dependabot
+on:
+  workflow_dispatch:
+
+jobs:
+  run-dependabot:
+    permissions:
+      # Important not to give Dependabot write access in case it runs arbitrary
+      # code as some ecosystems do.
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download CLI
+        run: |
+          gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
+          tar xzvf *.tar.gz >/dev/null 2>&1
+          ./dependabot --version
+
+      - name: Run Dependabot
+        env:
+          LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./dependabot update -f .github/dependabot/go.yml --timeout 20m > result.jsonl
+
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependabot-result
+          path: result.jsonl
+
+  create-prs:
+    permissions:
+      # This job creates PRs, so it needs write access.
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: run-dependabot
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download result
+        uses: actions/download-artifact@v4
+        with:
+          name: dependabot-result
+
+      - name: Create PRs
+        run: bash create.sh result.jsonl

--- a/create.sh
+++ b/create.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This script takes a jsonl file as input which is the stdout of a Dependabot CLI run.
+# It takes the `type: create_pull_request` events and creates a pull request for each of them
+# by using git commands.
+
+# Note at this time there is minimal error handling.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <result.jsonl>"
+  exit 1
+fi
+
+INPUT="$1"
+
+# Parse each create_pull_request event
+jq -c 'select(.type == "create_pull_request")' "$INPUT" | while read -r event; do
+  # Extract fields
+  BASE_SHA=$(echo "$event" | jq -r '.expect.data."base-commit-sha"')
+  PR_TITLE=$(echo "$event" | jq -r '.expect.data."pr-title"')
+  PR_BODY=$(echo "$event" | jq -r '.expect.data."pr-body"')
+  COMMIT_MSG=$(echo "$event" | jq -r '.expect.data."commit-message"')
+  BRANCH_NAME="dependabot/$(echo "$PR_TITLE" | tr ' /' '__' | tr -cd '[:alnum:]_-')"
+
+  echo "Processing PR: $PR_TITLE"
+  echo "  Base SHA: $BASE_SHA"
+  echo "  Branch: $BRANCH_NAME"
+
+  # Create and checkout new branch from base commit
+  git fetch origin
+  git checkout "$BASE_SHA"
+  git checkout -b "$BRANCH_NAME"
+
+  # Apply file changes
+  echo "$event" | jq -c '.expect.data."updated-dependency-files"[]' | while read -r file; do
+    FILE_PATH=$(echo "$file" | jq -r '.directory + "/" + .name' | sed 's#^/##')
+    DELETED=$(echo "$file" | jq -r '.deleted')
+    if [ "$DELETED" = "true" ]; then
+      git rm -f "$FILE_PATH" || true
+    else
+      mkdir -p "$(dirname "$FILE_PATH")"
+      echo "$file" | jq -r '.content' > "$FILE_PATH"
+      git add "$FILE_PATH"
+    fi
+  done
+
+  # Commit and push
+  git commit -m "$COMMIT_MSG"
+  git push origin "$BRANCH_NAME"
+
+  # Create PR using gh CLI
+  gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH_NAME" || true
+
+  # Return to main branch for next PR
+  git checkout main
+done

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,3 @@
+# example
+
+This is an example Go project that will be updated using the example Dependabot CLI workflow.

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,0 +1,8 @@
+module github.com/dependabot/example-cli-usage/example
+
+go 1.24.2
+
+require (
+	golang.org/x/net v0.32.0
+	golang.org/x/text v0.21.0
+)

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,8 @@
+package example
+
+import (
+	_ "golang.org/x/net/html"
+	_ "golang.org/x/text"
+)
+
+func main() {}


### PR DESCRIPTION
This is an example of how to use the CLI in "standalone" mode, as opposed to the hosted Dependabot that GitHub runs.

It will allow us to remove [dependabot-script](https://github.com/dependabot/dependabot-script).